### PR TITLE
[WIP] This commit will change the Git default Editor.

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -11,7 +11,7 @@
   grep = auto
 
 [core]
-  editor = /usr/bin/vim
+	editor = /usr/local/bin/mvim
 
 [alias]
   # log関連

--- a/.zshrc
+++ b/.zshrc
@@ -314,7 +314,7 @@ case ${OSTYPE} in
     # For Mac
     alias eject='drutil eject'
     # vim
-    alias vi="`find /usr/local/Caskroom/macvim -name 'Vim' | xargs ls -1t | head -1`"
+    alias vi='/usr/local/bin/mvim'
     ;;
 
   linux*)


### PR DESCRIPTION
Since the `brew` command's specification change,
`git` command does refer to `/usr/bin/vi`.

This `vi` is an old version,
so I'd like to refer to the `brew` version of `vi`.