### PR TITLE
Add `-d` option to tmux

### DIFF
--- a/.zsh.d/alias.zsh
+++ b/.zsh.d/alias.zsh
@@ -5,7 +5,7 @@
   alias ld="ls -hl | grep ^d"
 
   alias screen='screen -U -D -RR'
-  alias tmux="if tmux has; then tmux attach; else tmux new; fi"
+  alias tmux="if tmux has; then tmux attach -d; else tmux new; fi"
 
   # Settings depending on the OSes
   case ${OSTYPE} in


### PR DESCRIPTION
When executing `tmux attach`, add `-d` option automatically.